### PR TITLE
Passing commands through -o fails, recluster didn't work for all

### DIFF
--- a/maintenance.py
+++ b/maintenance.py
@@ -86,12 +86,24 @@ def maintenance_callback(event):
     if event:
         # print('Undergoing host maintenance: {}'.format(event))
         # realistically, any sort of maintenence event should drain aerospike
-        call([ASINFO, "-v", "quiesce:"].extend(args.options.split()))
+        asinfo1 = [ASINFO, "-v", "quiesce:"]
+        asinfo1.extend(args.options.split())
+        call(asinfo1)
+
+        #call([ASINFO, "-v", "quiesce:"].extend(args.options.split()))
     else:
         # print('Finished host maintenance')
-        call([ASINFO, "-v", "quiesce-undo:"].extend(args.options.split()))
+        asinfo2 = [ASINFO, "-v", "quiesce-undo:"]
+        asinfo2.extend(args.options.split())
+        call(asinfo2)
 
-    call([ASADM, "-e", "recluster:"].extend(args.options.split()))
+        # call([ASINFO, "-v", "quiesce-undo:"].extend(args.options.split()))
+
+    asadm = [ASADM, "-e", "asinfo -v \"recluster:\""]
+    asadm.extend(args.options.split())
+    call(asadm)
+
+    #call([ASADM, "-e", "recluster:"].extend(args.options.split()))
 
 
 def main():

--- a/maintenance.py
+++ b/maintenance.py
@@ -90,20 +90,15 @@ def maintenance_callback(event):
         asinfo1.extend(args.options.split())
         call(asinfo1)
 
-        #call([ASINFO, "-v", "quiesce:"].extend(args.options.split()))
     else:
         # print('Finished host maintenance')
         asinfo2 = [ASINFO, "-v", "quiesce-undo:"]
         asinfo2.extend(args.options.split())
         call(asinfo2)
 
-        # call([ASINFO, "-v", "quiesce-undo:"].extend(args.options.split()))
-
     asadm = [ASADM, "-e", "asinfo -v \"recluster:\""]
     asadm.extend(args.options.split())
     call(asadm)
-
-    #call([ASADM, "-e", "recluster:"].extend(args.options.split()))
 
 
 def main():


### PR DESCRIPTION
On a customer site, fixing the script so it won't fail when passing -o parameters.
the recluster command didn't work as well, so that is fixed too.

Tested on live cluster