### PR TITLE
Add option to enable persistence to the status, to allow restart-ability to the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ nohup ./maintenance.py &
 # Parameters:
 
 ```
-usage: maintenance.py [-h] [-o OPTIONS] [-p | -n]
+usage: maintenance.py [-h] [-o OPTIONS] [-t TIMEOUT] [-p | -n]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -33,6 +33,9 @@ optional arguments:
                         Additional options to pass into asinfo. Can be
                         anything except commands, ie: "-v $COMMAND". Entire
                         string must be quoted, eg: -o="-u admin -p admin"
+  -t TIMEOUT, --timeout TIMEOUT
+                        Timeout for the Google metadata service in seconds, up
+                        to 3600 (default 3600)
   -p, --persist         Persist the last event to file
   -n, --non-persist     Disable persist the last event to file (default)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To mitigate the impact, the node will be drained via the `asinfo -v quiesce` com
 
 # Requirements
 
-python requests 2.20.1  
+python requests 2.20.1
 asinfo (from aerospike-tools)
 
 
@@ -19,13 +19,13 @@ This script should run on every Aerospike node, as maintenance events are local 
 run with nohup:
 
 ```
-nohup ./maintenance.py & 
+nohup ./maintenance.py &
 ```
 
 # Parameters:
 
 ```
-usage: maintenance.py [-h] [-o OPTIONS]
+usage: maintenance.py [-h] [-o OPTIONS] [-p | -n]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -33,11 +33,14 @@ optional arguments:
                         Additional options to pass into asinfo. Can be
                         anything except commands, ie: "-v $COMMAND". Entire
                         string must be quoted, eg: -o="-u admin -p admin"
+  -p, --persist         Persist the last event to file
+  -n, --non-persist     Disable persist the last event to file (default)
+
 ```
 
 
 Example with user/password:
 
 ```
-nohup ./maintenance.py -o="-u admin -p admin" & 
+nohup ./maintenance.py -o="-u admin -p admin" &
 ```

--- a/maintenance.py
+++ b/maintenance.py
@@ -40,7 +40,7 @@ AGM_LEVEL = logging.INFO
 MAX_TIMEOUT = 3600
 
 # persist status over runs
-is_persistent_last_event = True
+is_persistent_last_event = False
 AS_TMP_LAST_STATUS_FILE = '/tmp/agm_last_status.tmp'
 
 # logger setup

--- a/maintenance.py
+++ b/maintenance.py
@@ -40,7 +40,7 @@ AGM_LEVEL = logging.INFO
 MAX_TIMEOUT = 3600
 
 # persist status over runs
-is_persistent_last_event = False
+is_persistent_last_event = False  # the default set at the parser
 AS_TMP_LAST_STATUS_FILE = '/tmp/agm_last_status.tmp'
 
 # logger setup
@@ -62,6 +62,20 @@ parser.add_argument("-o",
                     default = "",
                     help = "Additional options to pass into asinfo. Can be anything except commands, ie: \"-v $COMMAND\". Entire string must be quoted, eg: -o=\"-u admin -p admin\"")
 
+feature_parser = parser.add_mutually_exclusive_group(required=False)
+feature_parser.add_argument("-p",
+                    "--persist",
+                    dest="is_persistent_last_event",
+                    action="store_true",
+                    help="Persist the last event to file")
+
+feature_parser.add_argument("-n",
+                    "--non-persist",
+                    dest="is_persistent_last_event",
+                    action="store_false",
+                    help="Disable persist the last event to file (default)")
+
+parser.set_defaults(is_persistent_last_event=False)
 args = parser.parse_args()
 
 logger.debug('options: %s', args.options)
@@ -170,6 +184,7 @@ def wait_for_maintenance(callback):
                 set_last_maintenance_event(last_maintenance_event)
 
             callback(maintenance_event)
+
 
 def maintenance_callback(event):
     if event != "NONE":


### PR DESCRIPTION
In some cases the script exits (or hangs) on various (unknown) reasons, leaving the cluster in quiesce mode. Saving the state to a file will allow restarting the script and if the node is out of maintenance mode, it will automatically undo the quiesce.